### PR TITLE
Correct default name for input that is correctly overwritten by attributes.yml

### DIFF
--- a/controls/bash_works.rb
+++ b/controls/bash_works.rb
@@ -1,6 +1,6 @@
 title 'Tests to confirm bash works as expected'
 
-plan_name = input('plan_name', value: 'binutils')
+plan_name = input('plan_name', value: 'bash')
 plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
 hab_path = input('hab_path', value: 'hab')
 


### PR DESCRIPTION
Minor correction.

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
